### PR TITLE
Remove sink processing from the tree

### DIFF
--- a/lib/yggdrasil/src/sink.rs
+++ b/lib/yggdrasil/src/sink.rs
@@ -63,11 +63,11 @@ impl SinkRef {
         Ok(inner)
     }
 
-    pub(super) fn on_ready(&self, tree: &SubTree) -> Fallible<()> {
+    pub fn on_ready(&self, tree: &SubTree) -> Fallible<()> {
         self.sink.borrow_mut().on_ready(tree)
     }
 
-    pub(super) fn add_path(&self, path: &str, tree: &SubTree) -> Fallible<()> {
+    pub fn add_path(&self, path: &str, tree: &SubTree) -> Fallible<()> {
         self.sink.borrow_mut().add_path(path, tree)
     }
 

--- a/lib/yggdrasil/src/sink.rs
+++ b/lib/yggdrasil/src/sink.rs
@@ -71,7 +71,7 @@ impl SinkRef {
         self.sink.borrow_mut().add_path(path, tree)
     }
 
-    pub(super) fn values_updated(&self, values: &[(String, Value)]) -> Fallible<()> {
+    pub fn values_updated(&self, values: &[(String, Value)]) -> Fallible<()> {
         self.sink.borrow_mut().values_updated(values)
     }
 }

--- a/lib/yggdrasil/src/tree.rs
+++ b/lib/yggdrasil/src/tree.rs
@@ -140,13 +140,13 @@ pub struct Tree {
 }
 
 impl Tree {
-    pub fn handle_event(&self, path: &str, mut value: Value) -> Fallible<()> {
+    pub fn handle_event(&self, path: &str, mut value: Value) -> Fallible<HashMap<String, Vec<(String, Value)>>> {
         // FIXME: make this mutable once we back off systems
         //self.generation += 1;
         value.set_generation(self.generation);
 
         let source = self.lookup(path)?;
-        source.handle_event(value, self)?;
+        source.handle_event(value, self)?; // cache the value
         let sink_nodes = source.get_sink_nodes_observing()?;
 
         let mut groups = HashMap::new();
@@ -163,10 +163,7 @@ impl Tree {
                 }
             }
         }
-        for (kind, values) in &groups {
-            self.sink_handlers[kind].values_updated(values)?;
-        }
-        Ok(())
+        Ok(groups)
     }
 
     pub fn root(&self) -> NodeRef {

--- a/lib/yggdrasil/src/tree.rs
+++ b/lib/yggdrasil/src/tree.rs
@@ -125,9 +125,6 @@ impl TreeBuilder {
             .link_and_validate_inputs()?
             .map_inputs_to_outputs()?;
 
-        for sink in tree.sink_handlers.values() {
-            sink.on_ready(&tree.root.subtree_here(&tree)?)?;
-        }
         Ok(tree)
     }
 }
@@ -199,8 +196,14 @@ impl Tree {
         Ok(self)
     }
 
-    pub(super) fn subtree_at(&self, root: &NodeRef) -> Fallible<SubTree> {
+    pub fn subtree_at(&self, root: &NodeRef) -> Fallible<SubTree> {
         SubTree::new(self, root)
+    }
+
+    pub fn find_sinks(&self, name: &str) -> Vec<String> {
+        let mut matching = Vec::new();
+        self.root().find_sinks(name, &mut matching);
+        matching
     }
 }
 
@@ -279,6 +282,20 @@ impl NodeRef {
             child_name,
             self.path_str()
         ))
+    }
+
+    fn find_sinks(&self, sink_name: &str, matching: &mut Vec<String>) {
+        if let Some(name) = self.maybe_sink_kind() {
+            if name == sink_name {
+                matching.push(self.path_str());
+            }
+        }
+        for (name, child) in &self.0.borrow().children {
+            if name == "." || name == ".." {
+                continue;
+            }
+            child.find_sinks(sink_name, matching);
+        }
     }
 
     pub fn add_child(&self, name: &str) -> Fallible<NodeRef> {
@@ -630,6 +647,13 @@ impl NodeRef {
             "runtime: tried to get sink kind of the non-sink node at {}",
             self.path_str()
         )
+    }
+
+    pub fn maybe_sink_kind(&self) -> Option<String> {
+        if let Some((ref kind, _)) = self.0.borrow().sink {
+            return Some(kind.to_owned());
+        }
+        None
     }
 }
 

--- a/src/oh/color.rs
+++ b/src/oh/color.rs
@@ -42,8 +42,6 @@ impl BHS {
         };
 
         let saturation = if max == 0.0 { 0.0 } else { (max - min) / max };
-        println!("SAT: {}", saturation);
-
         let v = max;
 
         let bhs = Self {
@@ -120,7 +118,7 @@ impl Color {
         } else if let Some(captures) = REGEX_MIRED.captures(s) {
             return Ok(Color::Mired(Mired::new(captures[1].parse()?)?));
         }
-        bail!("color: not a color: '{}'", s);
+        bail!("color: not a color: '{}'", s)
     }
 }
 

--- a/src/oh/db_server.rs
+++ b/src/oh/db_server.rs
@@ -25,6 +25,13 @@ impl DBServer {
             .add_source_handler("legacy-mcu", &legacy_mcu)?
             .add_sink_handler("hue", &hue)?
             .build_from_file(filename)?;
+
+        let paths = tree.find_sinks("hue");
+        for path in &paths {
+            hue.add_path(&path, &tree.subtree_at(&tree.lookup(&path)?)?)?;
+        }
+        hue.on_ready(&tree.subtree_at(&tree.root())?)?;
+
         let db_server = Self {
             tree,
             clock,

--- a/src/oh/db_server.rs
+++ b/src/oh/db_server.rs
@@ -56,7 +56,11 @@ impl Handler<HandleEvent> for DBServer {
     fn handle(&mut self, msg: HandleEvent, _ctx: &mut Context<Self>) -> Self::Result {
         trace!("db server: recvd event {} <- {}", msg.path, msg.value);
         match self.tree.handle_event(&msg.path, msg.value) {
-            Ok(_) => (),
+            Ok(groups) => {
+                if let Some(parts) = groups.get("hue") {
+                    self.hue.values_updated(parts)?;
+                }
+            },
             Err(e) => error!("db server: failed to handle event: {}", e),
         }
         Ok(())


### PR DESCRIPTION
If we need an interface for this in the tree it tremendously increases complexity for very little advantage.